### PR TITLE
update ChatMemberUpdated model

### DIFF
--- a/pyteledantic/models.py
+++ b/pyteledantic/models.py
@@ -802,7 +802,7 @@ class ChatMemberUpdated(BaseModel):
         ChatMemberOwner, ChatMemberAdministrator,
         ChatMemberMember, ChatMemberRestricted,
         ChatMemberLeft, ChatMemberBanned]
-    invite_link: ChatInviteLink
+    invite_link: Optional[ChatInviteLink]
 
 
 class Update(BaseModel):


### PR DESCRIPTION
There was an error when attempting to create Update class from Telegram JSON answer. Telegram JSON was not include `invite_link` field, but this field in ChatMemberUpdate model was not Optional.